### PR TITLE
Add the ability to support arbitrary scripts via JSON in the URL parameter

### DIFF
--- a/src/js/roles/character_sheet.tsx
+++ b/src/js/roles/character_sheet.tsx
@@ -184,7 +184,7 @@ export function CharacterSheet(props: {
       };
 
   const [qrUrl, setQrUrl] = useState<string | null>(null);
-  const qrDest = `${window.location.origin}/script.html?id=${script.id}`;
+  const qrDest = `${window.location.origin}${window.location.pathname}?id=${script.id}`;
 
   return (
     <div className={visibleClass(active)}>

--- a/src/js/roles/character_sheet.tsx
+++ b/src/js/roles/character_sheet.tsx
@@ -184,7 +184,7 @@ export function CharacterSheet(props: {
       };
 
   const [qrUrl, setQrUrl] = useState<string | null>(null);
-  const qrDest = `${window.location.origin}${window.location.pathname}?id=${script.id}`;
+  const qrDest = window.location.href;
 
   return (
     <div className={visibleClass(active)}>

--- a/src/js/select_script.ts
+++ b/src/js/select_script.ts
@@ -1,6 +1,6 @@
-import { ScriptData } from "./botc/script";
-import { getScripts } from "./get_scripts";
-import { getAuthenticated } from "randomizer/state";
+import {ScriptData} from "./botc/script";
+import {getScripts} from "./get_scripts";
+import {getAuthenticated} from "randomizer/state";
 
 function selectedScriptId(): string {
   if (window.location.hash != "") {
@@ -16,7 +16,30 @@ function selectedScriptId(): string {
   return "178";
 }
 
+function getJson(): ScriptData | null {
+  const params = new URLSearchParams(window.location.search);
+  const json = params.get("json");
+  if (json === null) {
+    return null
+  }
+  const parsed = JSON.parse(json);
+  const title = parsed[0];
+  const characters = parsed.slice(1);
+
+  return {
+    pk: 0,
+    title: title,
+    author: "author",
+    characters: characters,
+    allAmne: false,
+  };
+}
+
 export async function selectedScript(): Promise<ScriptData> {
+  const json = getJson();
+  if (json != null) {
+    return json;
+  }
   const id = selectedScriptId();
   const scripts = (await getScripts()).scripts;
   const script = scripts.find((s) => s.pk.toString() == id);


### PR DESCRIPTION
Add the ability to bring up a script page for an arbitrary script passed in to the `json=` URL parameter.  For now, the JSON doesn't quite match that generated by the script tool and is an array of strings, first element is the script name and subsequent elements are the characters on the script.  Behavior is undefined if not entered in order of all characters of each category in order Townsfolk, Outsiders, Minion, Demon.