### PR TITLE
Upgrade to TypeScript 5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "querystring-es3": "^0.2.1",
     "stream-browserify": "^3.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "5.5.4",
+    "typescript": "~5.6",
     "url": "^0.11.0",
     "util": "^0.12.3",
     "vm-browserify": "^1.1.2",

--- a/src/js/randomizer/history.ts
+++ b/src/js/randomizer/history.ts
@@ -87,8 +87,8 @@ export type SetHistory = Dispatch<
 >;
 
 export function pureHistoryApply<T>(
-  setHistory: Dispatch<SetStateAction<History<T>>>,
-  a: PureHistoryAction<T>,
+  setHistory: Dispatch<SetStateAction<History<Partial<T>>>>,
+  a: PureHistoryAction<Partial<T>>,
 ) {
   setHistory((h) => historyStep(h, a).h);
 }

--- a/src/js/randomizer/history.ts
+++ b/src/js/randomizer/history.ts
@@ -86,9 +86,9 @@ export type SetHistory = Dispatch<
   SetStateAction<History<Partial<ScriptState>>>
 >;
 
-export function pureHistoryApply<T>(
-  setHistory: Dispatch<SetStateAction<History<Partial<T>>>>,
-  a: PureHistoryAction<Partial<T>>,
+export function pureHistoryApply(
+  setHistory: SetHistory,
+  a: PureHistoryAction<Partial<ScriptState>>,
 ) {
   setHistory((h) => historyStep(h, a).h);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6795,10 +6795,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@5.5.4:
-  version "5.5.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
-  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
+typescript@~5.6:
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
+  integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
* Fixes https://github.com/tchajed/botc-tools/issues/26

I'm pretty sure the new version of TypeScript is pointing out that we're passing a `Partial<ScriptState>` to a function that expects a `ScriptState`. This PR just changes the function to expect a `Partial<ScriptState>` instead.