### PR TITLE
Implement Hermit's modifications

### DIFF
--- a/src/js/botc/setup.ts
+++ b/src/js/botc/setup.ts
@@ -168,6 +168,7 @@ export const SetupChanges: { [key: string]: SetupModification } = {
   godfather: outsiders(+1, -1),
   sentinel: outsiders(0, +1, -1),
   lyingppp: outsiders(+1, -1),
+  hermit: outsiders(0, -1),
   huntsman: { type: "huntsman" },
   riot: { type: "riot" },
   legion: { type: "legion" },

--- a/src/js/randomizer/components/setup_help.tsx
+++ b/src/js/randomizer/components/setup_help.tsx
@@ -98,6 +98,10 @@ function ModificationExplanation(props: {
       if (arrayEq(mod.delta, [0, +1]) || arrayEq(mod.delta, [+1, 0])) {
         return <span>(+0 or +1 outsider)</span>;
       }
+      // hermit
+      if (arrayEq(mod.delta, [0, -1]) || arrayEq(mod.delta, [-1, 0])) {
+        return <span>(&#x2212;0 or &#x2212;1 outsider)</span>;
+      }
       // sentinel
       if (arrayEq(mod.delta, [0, +1, -1]) || arrayEq(mod.delta, [+1, 0, -1])) {
         return <span>(might be +1 or &#x2212;1 outsider)</span>;

--- a/src/js/randomizer/components/setup_help.tsx
+++ b/src/js/randomizer/components/setup_help.tsx
@@ -98,10 +98,6 @@ function ModificationExplanation(props: {
       if (arrayEq(mod.delta, [0, +1]) || arrayEq(mod.delta, [+1, 0])) {
         return <span>(+0 or +1 outsider)</span>;
       }
-      // hermit
-      if (arrayEq(mod.delta, [0, -1]) || arrayEq(mod.delta, [-1, 0])) {
-        return <span>(&#x2212;0 or &#x2212;1 outsider)</span>;
-      }
       // sentinel
       if (arrayEq(mod.delta, [0, +1, -1]) || arrayEq(mod.delta, [+1, 0, -1])) {
         return <span>(might be +1 or &#x2212;1 outsider)</span>;
@@ -177,6 +173,9 @@ function ModificationExplanation(props: {
     }
     case "xaan": {
       return <span>(X outsiders)</span>;
+    }
+    case "hermit": {
+      return <span>(&#x2212;0 or &#x2212;1 outsider)</span>;
     }
     case "lordoftyphon":
       return (


### PR DESCRIPTION
- The baseline effect is -0 or -1 Outsiders.
- A selected Hermit inherits other setup modifications (currently just
  Drunk I believe).
- Hermit can "remove itself" but still have the -1 Outsider effect. The
  result is that -1 Outsider is permitted on any script containing
  Hermit.