### PR TITLE
Fix how Hermit is handled

### DIFF
--- a/src/js/botc/random_setup.ts
+++ b/src/js/botc/random_setup.ts
@@ -28,7 +28,7 @@ function nextRandomChar(
 ): { id: string } | "done" | "fail" {
   const newDists = targetDistributions(
     numPlayers,
-    modifyingCharacters(selection),
+    modifyingCharacters(selection, characters),
     characters,
   );
 

--- a/src/js/randomizer/components/setup_help.tsx
+++ b/src/js/randomizer/components/setup_help.tsx
@@ -300,7 +300,7 @@ export function SetupModifiers(props: {
 }) {
   const { numPlayers, selection } = props;
   const characters = useContext(CharacterContext);
-  const modified = modifyingCharacters(selection);
+  const modified = modifyingCharacters(selection, characters);
   const newDistributions = targetDistributions(
     numPlayers,
     modified,
@@ -398,7 +398,7 @@ export function BagSetupHelp(props: {
 }): React.JSX.Element {
   const { numPlayers, selection } = props;
   const characters = useContext(CharacterContext);
-  const modified = modifyingCharacters(selection);
+  const modified = modifyingCharacters(selection, characters);
   const targets = targetDistributions(numPlayers, modified, characters);
   const selected = characters.filter((c) => selection.has(c.id));
   const actual = effectiveDistribution(numPlayers, selected);

--- a/src/js/randomizer/randomizer.tsx
+++ b/src/js/randomizer/randomizer.tsx
@@ -120,7 +120,7 @@ export function Randomizer({
 
   const targetDists = targetDistributions(
     numPlayers,
-    modifyingCharacters(selection),
+    modifyingCharacters(selection, characters),
     characters,
   );
   const selectedCharInfo: CharacterInfo[] = [...selection].map((id) =>


### PR DESCRIPTION
There was a bug in how the other outsider's modifications were applied. In the process this commit also adds Hermit to the setup modification list automatically, even if it isn't selected.