### PR TITLE
Replace `setInterval()` with `setTimeout()` in `search.worker.ts`

### DIFF
--- a/src/js/listing/search.worker.ts
+++ b/src/js/listing/search.worker.ts
@@ -84,18 +84,18 @@ function getTitleAuthorSearcher(
 /**
  * Queue up one incoming request, overwriting it whenever the user sends us new data
  */
-let incomingRequest: SearchWorkerRequest | undefined = undefined;
+let incomingRequestTimeout: ReturnType<typeof setTimeout> | undefined =
+  undefined;
 onmessage = ({ data }: MessageEvent<SearchWorkerRequest>) => {
-  incomingRequest = data;
-};
-
-setInterval(function handleIncomingRequest() {
-  if (incomingRequest) {
-    const response = runSearch(incomingRequest);
-    postMessage(response);
+  if (incomingRequestTimeout) {
+    clearTimeout(incomingRequestTimeout);
   }
-  incomingRequest = undefined;
-});
+  incomingRequestTimeout = setTimeout(() => {
+    const response = runSearch(data);
+    postMessage(response);
+    incomingRequestTimeout = undefined;
+  });
+};
 
 function runSearch({
   query,


### PR DESCRIPTION
Among other things, https://github.com/tchajed/botc-tools/pull/38 fixes a queuing problem where, if we type faster than it takes for the searches to complete, a queue of search actions will build up, and we'll wind up wasting time running one search for every keystroke, watching the results spasm back and forth until they finally align with the current query. There are a few ways to solve this, but the one I opted for was to store the most recent request and then only process the most recent request, within a `setInterval()` loop.

This didn't quite sit right with me though. A `setInterval()` loop will keep running whether there's work to do or not. We should only do work when there actually _is_ work to do.

This PR replaces `setInterval()` with `setTimeout()`. The same principle applies - we avoid running searches for interim keystrokes, cancelling queued work with `clearTimeout()`. Testing shows that we're still avoiding interim queries, and the performance profile shows that the `"Script searcher"` worker no longer consumes CPU when not in use.