### PR TITLE
Switch from azurewebsites URL to botcscripts.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ yarn fetch-assets
 ```
 
 This fetches character icons, and all the scripts from
-<https://botc-scripts.azurewebsites.net> - it will take a couple minutes.
+<https://botcscripts.com> - it will take a couple minutes.
 Running multiple times won't re-download images and scripts. If you want to
 re-fetch, delete the downloaded assets:
 

--- a/fetch_assets/src/all_scripts.ts
+++ b/fetch_assets/src/all_scripts.ts
@@ -16,16 +16,13 @@ interface Resp {
 async function getPage(
   page: number,
 ): Promise<{ count: number; data: ScriptData[]; next: boolean }> {
-  const resp = await axios.get(
-    "https://botc-scripts.azurewebsites.net/api/scripts/",
-    {
-      maxRate: 3000 * 1024, // 3MB/s
-      params: {
-        format: "json",
-        page,
-      },
+  const resp = await axios.get("https://botcscripts.com/api/scripts/", {
+    maxRate: 3000 * 1024, // 3MB/s
+    params: {
+      format: "json",
+      page,
     },
-  );
+  });
   const data: Resp = resp.data;
   return {
     count: data.count,

--- a/fetch_assets/src/get_script.ts
+++ b/fetch_assets/src/get_script.ts
@@ -14,7 +14,7 @@ export type ScriptsFile = {
   lastUpdate: string;
 };
 
-const apiBase = "https://botc-scripts.azurewebsites.net/api";
+const apiBase = "https://botcscripts.com/api";
 
 type ContentRow =
   | { id: string }


### PR DESCRIPTION
The URL https://botc-scripts.azurewebsites.net/ will stop working on August 4th.