### PR TITLE
Add buttons to paste JSON from clipboard and upload JSON file

### DIFF
--- a/src/js/select_script.ts
+++ b/src/js/select_script.ts
@@ -26,7 +26,7 @@ interface ScriptCharacter {
   id: string;
 }
 
-function parseJson(json: string): ScriptData {
+export function parseJson(json: string): ScriptData {
   const parsed: (ScriptMeta | ScriptCharacter | string)[] = JSON.parse(json);
   const meta = parsed.find(
     (item): item is ScriptMeta =>


### PR DESCRIPTION
Sometimes we have custom scripts that are not uploaded to the botcscripts website. Apparently botc-tools.xyz accepts bring-your-own-JSONs in the URL through `script.html?json=<json>` but this is very non-obvious from the GUI and I only found this through the code. This PR just adds two buttons to paste from clipboard or upload file directly.

<img width=30% height=30% alt="image" src="https://github.com/user-attachments/assets/9f7445c5-36dd-4209-a951-588c7a9c4eef" />