### PR TITLE
Add support for "loric" role type in game logic

### DIFF
--- a/src/js/botc/roles.ts
+++ b/src/js/botc/roles.ts
@@ -31,6 +31,7 @@ export const RoleTypes = [
   "minion",
   "demon",
   "fabled",
+  "loric",
   "travellers",
 ] as const;
 export type RoleType = (typeof RoleTypes)[number];
@@ -70,7 +71,7 @@ export class CharacterInfo {
   }
 
   get special(): boolean {
-    return ["travellers", "fabled"].includes(this.roleType);
+    return ["travellers", "fabled", "loric"].includes(this.roleType);
   }
 
   nightDetails(firstNight: boolean): NightAction | null {

--- a/src/js/botc/script.ts
+++ b/src/js/botc/script.ts
@@ -76,7 +76,8 @@ export function onlyBaseThree(characters: CharacterInfo[]): boolean {
     (c) =>
       c.edition != "other" ||
       c.roleType == "travellers" ||
-      c.roleType == "fabled",
+      c.roleType == "fabled" ||
+      c.roleType == "loric",
   );
 }
 

--- a/src/js/botc/setup.ts
+++ b/src/js/botc/setup.ts
@@ -201,7 +201,7 @@ export const SetupChanges: { [key: string]: SetupModification } = {
 };
 
 export function goesInBag(withLordOfTyphon: boolean, char: CardInfo): boolean {
-  if (char.roleType == "fabled") {
+  if (char.roleType == "fabled" || char.roleType == "loric") {
     return false;
   }
   if (withLordOfTyphon && char.roleType == "minion") {

--- a/src/js/components/nav.tsx
+++ b/src/js/components/nav.tsx
@@ -111,7 +111,8 @@ export function Nav(props: {
     dest: Page,
   ): React.MouseEventHandler<HTMLAnchorElement> {
     const newUrl = new URL(
-      `${window.location.origin}/script.html?page=${dest}&id=${id}`,
+      `./script.html?page=${dest}&id=${id}`,
+      window.location.href,
     );
     return (e) => {
       saveScroll(currentPage);

--- a/src/js/randomizer/selection.ts
+++ b/src/js/randomizer/selection.ts
@@ -37,7 +37,7 @@ export function requiredSelection(characters: CharacterInfo[]): Set<string> {
     required.add(demons[0].id);
   }
   for (const c of characters) {
-    if (c.roleType == "fabled") {
+    if (c.roleType == "fabled" || c.roleType == "loric") {
       required.add(c.id);
     }
   }

--- a/src/js/roles/character_sheet.tsx
+++ b/src/js/roles/character_sheet.tsx
@@ -116,7 +116,7 @@ function Character(props: {
 }
 
 function pluralRole(roleType: string): string {
-  return ["townsfolk", "fabled", "travellers"].includes(roleType)
+  return ["townsfolk", "fabled", "loric", "travellers"].includes(roleType)
     ? roleType
     : roleType + "s";
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,7 @@ function postHtmlPlugin() {
 }
 
 export default defineConfig({
+  base: "./",
   assetsInclude: ["icons/touch-icon.png"],
   build: {
     emptyOutDir: true,


### PR DESCRIPTION
This pull request introduces support for a new role type, `loric`, across several parts of the codebase. The main changes ensure that `loric` is treated similarly to existing special roles like `fabled` and `travellers` in role definitions, setup logic, script filtering, selection requirements, and UI pluralization.

Role definition and handling:

* Added `loric` to the `RoleTypes` array and updated the `CharacterInfo` class so that `loric` is considered a special role alongside `fabled` and `travellers`. [[1]](diffhunk://#diff-33f0dcf99a76d4de3eacdb145c7016294a7366caa02d110d3beacc7d1f9fbca7R34) [[2]](diffhunk://#diff-33f0dcf99a76d4de3eacdb145c7016294a7366caa02d110d3beacc7d1f9fbca7L73-R74)

Setup and filtering logic:

* Modified the `goesInBag` function in `setup.ts` so that characters with the `loric` role type do not go in the bag, matching the behavior for `fabled`.
* Updated the `onlyBaseThree` function in `script.ts` to include `loric` as a valid role type for base three scripts.

Selection and UI:

* Changed the `requiredSelection` function in `selection.ts` so that `loric` roles are always required selections, just like `fabled`.
* Updated the `pluralRole` function in `character_sheet.tsx` to treat `loric` as a plural role type for UI display purposes.